### PR TITLE
Window sizing

### DIFF
--- a/webp_gui.py
+++ b/webp_gui.py
@@ -244,40 +244,51 @@ class ImageConverterGUI(QMainWindow):
                 action.setChecked(False) # Revert check if failed
 
     def browse_input(self):
-        # This version prioritizes selecting a FOLDER for the "Input Folder/File" field.
-        # If a folder is selected, it's used.
-        # If folder selection is cancelled, it then offers to select a single FILE.
-        # This helps address the issue of not being able to select an input folder easily.
-
         current_path_in_lineedit = self.input_folder_line_edit.text().strip()
         start_dir = os.path.dirname(current_path_in_lineedit) if current_path_in_lineedit and (os.path.isfile(current_path_in_lineedit) or os.path.isdir(current_path_in_lineedit)) else os.path.expanduser("~")
         if not os.path.isdir(start_dir): # Ensure start_dir is a valid directory
              start_dir = os.path.expanduser("~")
 
+        # --- Option 1: Prioritize Folder Selection (fixes "can't select folder") ---
+        # This will first open a dialog to select a folder.
+        # If the user cancels, it then opens a dialog to select a single file.
+        
+        # Ask user what they want to select
+        msg_box = QMessageBox(self)
+        msg_box.setWindowTitle("Select Input Type")
+        msg_box.setText("What do you want to select as input?")
+        folder_button = msg_box.addButton("Select Folder", QMessageBox.ButtonRole.ActionRole)
+        file_button = msg_box.addButton("Select File", QMessageBox.ButtonRole.ActionRole)
+        cancel_button = msg_box.addButton(QMessageBox.StandardButton.Cancel)
+        # Apply theme to this QMessageBox if possible
+        if qt_material and hasattr(self, 'current_theme_name'):
+             qt_material.apply_stylesheet(msg_box, theme=self.current_theme_name)
+        
+        msg_box.exec()
 
-        # Attempt to select a folder first
-        folder_path = QFileDialog.getExistingDirectory(
-            self,
-            "Select Input Folder",
-            start_dir
-        )
+        selected_path = ""
 
-        if folder_path: # User selected a folder
-            self.input_folder_line_edit.setText(folder_path)
-            return
+        if msg_box.clickedButton() == folder_button:
+            path = QFileDialog.getExistingDirectory(
+                self,
+                "Select Input Folder",
+                start_dir
+            )
+            if path:
+                selected_path = path
+        elif msg_box.clickedButton() == file_button:
+            path, _ = QFileDialog.getOpenFileName(
+                self,
+                "Select Input File",
+                start_dir,
+                "Image Files (*.png *.jpg *.jpeg *.bmp *.tiff);;All Files (*)"
+            )
+            if path:
+                selected_path = path
+        # If cancel_button or dialog closed, selected_path remains empty
 
-        # If folder selection was cancelled (folder_path is empty),
-        # then offer to select a single file.
-        # This means if the user cancels the folder dialog, a file dialog will appear.
-        # This isn't ideal UX but allows both types of selection with one button for now.
-        file_path, _ = QFileDialog.getOpenFileName(
-            self,
-            "Select Input File",
-            start_dir,
-            "Image Files (*.png *.jpg *.jpeg *.bmp *.tiff);;All Files (*)"
-        )
-        if file_path: # User selected a file
-            self.input_folder_line_edit.setText(file_path)
+        if selected_path:
+            self.input_folder_line_edit.setText(selected_path)
 
 
     def browse_output_folder(self):


### PR DESCRIPTION
Explanation of this "Basic" Approach:
Clear Choice: When you click "Browse...", it now first asks if you want to select a "Folder" or a "File".
Select Folder: If you choose "Select Folder", it opens the standard dialog for selecting a directory. This robustly fixes the issue of not being able to select a folder. If you select a folder, its path goes into the input field. process_images will then find all images in this folder (and subfolders if "Process Subfolders" is checked).
Select File: If you choose "Select File", it opens the standard dialog for selecting a single image file. If you select a file, its path goes into the input field.
Cancel: If you cancel the initial choice or the subsequent file/folder dialog, nothing changes in the input field.
This approach:
Directly solves the "can't select a folder" problem.
Allows selecting a single file if needed.
Keeps the GUI interaction for the input field to providing a single path, which image_converter.py expects.
Implicitly handles "multiple files in a folder" if you select the folder containing them.
This is simpler than the auto-fallback two-dialog sequence and gives you explicit control over what kind of input you're providing.